### PR TITLE
fix: refuse adapter selection without game LUID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(mgpu_bridge SHARED
     src/dllmain.cpp
     src/diag.cpp
     src/adapter.cpp
+    src/adapter_selection.cpp
     src/worker.cpp
     src/gpu1_context.cpp
 )
@@ -114,3 +115,17 @@ target_link_libraries(mgpu_bridge PRIVATE
 # P0: warnings visible, not fatal. A compile error costs the same round
 # trip as a logic error and teaches less - keep the first-try bar low.
 target_compile_options(mgpu_bridge PRIVATE /W3)
+
+option(MGPU_BUILD_TESTS "Build CPU-only adapter policy tests" OFF)
+if(MGPU_BUILD_TESTS)
+    enable_testing()
+    add_executable(mgpu_adapter_selection_test
+        tests/adapter_selection_test.cpp
+        src/adapter_selection.cpp
+    )
+    target_include_directories(mgpu_adapter_selection_test PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME mgpu_adapter_selection_test
+             COMMAND mgpu_adapter_selection_test)
+endif()

--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -50,6 +50,7 @@
 #include <vector>
 
 #include "adapter.hpp"
+#include "adapter_selection.hpp"
 #include "diag.hpp"
 
 // get_native() returns uint64_t: unwrapping it to ID3D12Device * needs
@@ -278,6 +279,8 @@ namespace
         // adapter (a LUID match, never an index match).
         std::vector<size_t> hw;     // hardware adapters
         std::vector<size_t> cand;   // of those, luid != the game LUID
+        std::vector<choice_input> policy;
+        policy.reserve(S.table.size());
         for (size_t i = 0; i < S.table.size(); ++i)
         {
             // The flag is not reliable on its own - see the rule 3 note at
@@ -288,6 +291,7 @@ namespace
             const bool is_software =
                 (S.table[i].flags & DXGI_ADAPTER_FLAG_SOFTWARE) != 0 ||
                 S.table[i].vendor_id == 0x1414;
+            policy.push_back({S.table[i].luid, is_software, S.table[i].outputs});
             if (is_software)
             {
                 snprintf(line, sizeof line,
@@ -305,12 +309,30 @@ namespace
         const char *rule = "none";
         size_t sel = static_cast<size_t>(-1);
         bool degenerate = false;
+        const choice_result choice =
+            choose_adapter(policy.data(), policy.size(), game);
 
-        if (cand.size() == 1)
+        if (!choice.game_luid_found)
         {
-            // [rule 1] satisfied: exactly one candidate.
-            sel = cand[0];
-            rule = "exclusion (luid != swapchain game luid) + software filter";
+            // The authoritative game LUID is absent from the enumeration.
+            // Every hardware adapter is therefore an untrusted candidate;
+            // output count cannot identify the game's own card in this state.
+            snprintf(line, sizeof line,
+                     "[MGPU][T2] REFUSING: the swapchain-derived game luid=0x%08X-0x%08X matches "
+                     "no enumerated adapter (%zu hardware adapters, all candidates) - the "
+                     "game's own card is unidentified. Selecting nothing rather than guessing.",
+                     (unsigned)game.HighPart, (unsigned)game.LowPart, hw.size());
+            mgpu::diag::error(line);
+            rule = "none (refused: game luid not in adapter table)";
+        }
+        else if (choice.valid)
+        {
+            sel = choice.selected_index;
+            degenerate = choice.degenerate;
+            rule = degenerate
+                       ? "exclusion + software filter + output-count tiebreak "
+                         "(display on target card)"
+                       : "exclusion (luid != swapchain game luid) + software filter";
         }
         else if (cand.empty())
         {
@@ -342,49 +364,17 @@ namespace
             }
             if (hw.size() > 2)
             {
-                // This project's topology puts the display on the target
-                // card: prefer the single candidate that has outputs, when
-                // exactly one does. Any ambiguity refuses - a rig with
-                // displays on both cards breaks that rule silently.
-                size_t with_outputs = static_cast<size_t>(-1);
                 size_t n_with_outputs = 0;
                 for (size_t c : cand)
                     if (S.table[c].outputs > 0)
-                    {
-                        with_outputs = c;
                         ++n_with_outputs;
-                    }
-                if (n_with_outputs == 1)
-                {
-                    sel = with_outputs;
-                    degenerate = true;
-                    rule = "exclusion + software filter + output-count tiebreak "
-                           "(display on target card)";
-                }
-                else
-                {
-                    snprintf(line, sizeof line,
-                             "[MGPU][T2] REFUSING: %zu non-game hardware adapters remain and the "
-                             "output-count tiebreak is ambiguous (%zu with outputs>0) - it applies "
-                             "only when it picks exactly one. Selecting nothing rather than guessing.",
-                             cand.size(), n_with_outputs);
-                    mgpu::diag::error(line);
-                    rule = "none (refused: ambiguous)";
-                }
-            }
-            else
-            {
-                // Two hardware adapters total, both "candidates": the
-                // swapchain-derived game LUID matched no enumerated
-                // adapter. The game's own card is unidentified - refusing
-                // is the only safe outcome.
                 snprintf(line, sizeof line,
-                         "[MGPU][T2] REFUSING: the swapchain-derived game luid=0x%08X-0x%08X matches "
-                         "no enumerated adapter (%zu hardware adapters, all candidates) - the "
-                         "game's own card is unidentified. Selecting nothing rather than guessing.",
-                         (unsigned)game.HighPart, (unsigned)game.LowPart, hw.size());
+                         "[MGPU][T2] REFUSING: %zu non-game hardware adapters remain and the "
+                         "output-count tiebreak is ambiguous (%zu with outputs>0) - it applies "
+                         "only when it picks exactly one. Selecting nothing rather than guessing.",
+                         cand.size(), n_with_outputs);
                 mgpu::diag::error(line);
-                rule = "none (refused: game luid not in adapter table)";
+                rule = "none (refused: ambiguous)";
             }
         }
 

--- a/src/adapter_selection.cpp
+++ b/src/adapter_selection.cpp
@@ -1,66 +1,15 @@
 // MGPU Bridge - pure adapter-choice policy (T2)
 #include "adapter_selection.hpp"
 
-#include <string_view>
 #include <vector>
 
 namespace mgpu::adapter
 {
 namespace
 {
-    bool luid_eq(const LUID &a, const LUID &b) noexcept
+    bool luid_eq(const LUID &a, const LUID &b)
     {
         return a.LowPart == b.LowPart && a.HighPart == b.HighPart;
-    }
-
-    bool is_space(char c) noexcept
-    {
-        return c == ' ' || c == '\t' || c == '\r' || c == '\n';
-    }
-
-    std::string_view trim(std::string_view value) noexcept
-    {
-        while (!value.empty() && is_space(value.front())) value.remove_prefix(1);
-        while (!value.empty() && is_space(value.back())) value.remove_suffix(1);
-        return value;
-    }
-
-    bool equals_ascii_ci(std::string_view a, std::string_view b) noexcept
-    {
-        if (a.size() != b.size()) return false;
-        for (std::size_t i = 0; i < a.size(); ++i)
-        {
-            const char ac = (a[i] >= 'A' && a[i] <= 'Z')
-                          ? static_cast<char>(a[i] - 'A' + 'a') : a[i];
-            const char bc = (b[i] >= 'A' && b[i] <= 'Z')
-                          ? static_cast<char>(b[i] - 'A' + 'a') : b[i];
-            if (ac != bc) return false;
-        }
-        return true;
-    }
-
-    int hex_digit(char c) noexcept
-    {
-        if (c >= '0' && c <= '9') return c - '0';
-        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-        return -1;
-    }
-
-    bool parse_hex_word(std::string_view value, DWORD &out) noexcept
-    {
-        if (value.size() != 10 || value[0] != '0' ||
-            (value[1] != 'x' && value[1] != 'X'))
-            return false;
-        DWORD parsed = 0;
-        for (std::size_t i = 2; i < value.size(); ++i)
-        {
-            const int digit = hex_digit(value[i]);
-            if (digit < 0) return false;
-            parsed = (parsed << 4) | static_cast<DWORD>(digit);
-        }
-        out = parsed;
-        return true;
     }
 }
 
@@ -114,63 +63,5 @@ choice_result choose_adapter(const choice_input *entries, std::size_t count,
         }
     }
     return out;
-}
-
-selector_value parse_secondary_adapter(std::string_view value) noexcept
-{
-    value = trim(value);
-    if (equals_ascii_ci(value, "auto"))
-        return {selector_kind::automatic, {}};
-
-    // The bridge log prints high/low in this exact fixed-width form. Refuse
-    // every other spelling so a stale index cannot become a GPU choice.
-    if (value.size() != 21 || value[10] != '-')
-        return {selector_kind::invalid, {}};
-
-    DWORD high = 0, low = 0;
-    if (!parse_hex_word(value.substr(0, 10), high) ||
-        !parse_hex_word(value.substr(11, 10), low))
-        return {selector_kind::invalid, {}};
-
-    LUID luid{};
-    luid.HighPart = static_cast<LONG>(high);
-    luid.LowPart = low;
-    return {selector_kind::explicit_luid, luid};
-}
-
-explicit_choice choose_explicit_adapter(const selector_value &selector,
-                                         const choice_input *entries,
-                                         std::size_t count,
-                                         bool game_luid_known,
-                                         LUID game_luid) noexcept
-{
-    if (selector.kind != selector_kind::explicit_luid ||
-        (entries == nullptr && count != 0))
-        return {explicit_decision::invalid_selector,
-                static_cast<std::size_t>(-1), {}};
-    if (!game_luid_known)
-        return {explicit_decision::game_luid_unknown,
-                static_cast<std::size_t>(-1), {}};
-
-    std::size_t found = static_cast<std::size_t>(-1);
-    std::size_t matches = 0;
-    for (std::size_t i = 0; i < count; ++i)
-    {
-        if (!luid_eq(entries[i].luid, selector.luid))
-            continue;
-        found = i;
-        ++matches;
-    }
-    if (matches == 0)
-        return {explicit_decision::not_found, static_cast<std::size_t>(-1), {}};
-    if (matches != 1)
-        return {explicit_decision::ambiguous, static_cast<std::size_t>(-1), {}};
-    if (luid_eq(entries[found].luid, game_luid))
-        return {explicit_decision::target_is_game,
-                static_cast<std::size_t>(-1), {}};
-    if (entries[found].software)
-        return {explicit_decision::target_is_software,
-                static_cast<std::size_t>(-1), {}};
-    return {explicit_decision::selected, found, entries[found].luid};
 }
 }

--- a/src/adapter_selection.cpp
+++ b/src/adapter_selection.cpp
@@ -1,0 +1,176 @@
+// MGPU Bridge - pure adapter-choice policy (T2)
+#include "adapter_selection.hpp"
+
+#include <string_view>
+#include <vector>
+
+namespace mgpu::adapter
+{
+namespace
+{
+    bool luid_eq(const LUID &a, const LUID &b) noexcept
+    {
+        return a.LowPart == b.LowPart && a.HighPart == b.HighPart;
+    }
+
+    bool is_space(char c) noexcept
+    {
+        return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+    }
+
+    std::string_view trim(std::string_view value) noexcept
+    {
+        while (!value.empty() && is_space(value.front())) value.remove_prefix(1);
+        while (!value.empty() && is_space(value.back())) value.remove_suffix(1);
+        return value;
+    }
+
+    bool equals_ascii_ci(std::string_view a, std::string_view b) noexcept
+    {
+        if (a.size() != b.size()) return false;
+        for (std::size_t i = 0; i < a.size(); ++i)
+        {
+            const char ac = (a[i] >= 'A' && a[i] <= 'Z')
+                          ? static_cast<char>(a[i] - 'A' + 'a') : a[i];
+            const char bc = (b[i] >= 'A' && b[i] <= 'Z')
+                          ? static_cast<char>(b[i] - 'A' + 'a') : b[i];
+            if (ac != bc) return false;
+        }
+        return true;
+    }
+
+    int hex_digit(char c) noexcept
+    {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    }
+
+    bool parse_hex_word(std::string_view value, DWORD &out) noexcept
+    {
+        if (value.size() != 10 || value[0] != '0' ||
+            (value[1] != 'x' && value[1] != 'X'))
+            return false;
+        DWORD parsed = 0;
+        for (std::size_t i = 2; i < value.size(); ++i)
+        {
+            const int digit = hex_digit(value[i]);
+            if (digit < 0) return false;
+            parsed = (parsed << 4) | static_cast<DWORD>(digit);
+        }
+        out = parsed;
+        return true;
+    }
+}
+
+choice_result choose_adapter(const choice_input *entries, std::size_t count,
+                             LUID game_luid)
+{
+    choice_result out;
+    if (entries == nullptr && count != 0)
+        return out;
+
+    std::vector<std::size_t> hardware;
+    std::vector<std::size_t> candidates;
+    for (std::size_t i = 0; i < count; ++i)
+    {
+        const bool game_match = luid_eq(entries[i].luid, game_luid);
+        out.game_luid_found = out.game_luid_found || game_match;
+        if (entries[i].software)
+            continue;
+        hardware.push_back(i);
+        if (!game_match)
+            candidates.push_back(i);
+    }
+
+    // This gate must precede all candidate/tiebreak logic. Otherwise a
+    // missing game LUID turns every hardware adapter into a false candidate.
+    if (!out.game_luid_found || candidates.empty())
+        return out;
+
+    if (candidates.size() == 1)
+    {
+        out.valid = true;
+        out.selected_index = candidates[0];
+        return out;
+    }
+
+    if (hardware.size() > 2)
+    {
+        std::size_t with_outputs = static_cast<std::size_t>(-1);
+        std::size_t count_with_outputs = 0;
+        for (const std::size_t i : candidates)
+            if (entries[i].outputs > 0)
+            {
+                with_outputs = i;
+                ++count_with_outputs;
+            }
+        if (count_with_outputs == 1)
+        {
+            out.valid = true;
+            out.degenerate = true;
+            out.selected_index = with_outputs;
+        }
+    }
+    return out;
+}
+
+selector_value parse_secondary_adapter(std::string_view value) noexcept
+{
+    value = trim(value);
+    if (equals_ascii_ci(value, "auto"))
+        return {selector_kind::automatic, {}};
+
+    // The bridge log prints high/low in this exact fixed-width form. Refuse
+    // every other spelling so a stale index cannot become a GPU choice.
+    if (value.size() != 21 || value[10] != '-')
+        return {selector_kind::invalid, {}};
+
+    DWORD high = 0, low = 0;
+    if (!parse_hex_word(value.substr(0, 10), high) ||
+        !parse_hex_word(value.substr(11, 10), low))
+        return {selector_kind::invalid, {}};
+
+    LUID luid{};
+    luid.HighPart = static_cast<LONG>(high);
+    luid.LowPart = low;
+    return {selector_kind::explicit_luid, luid};
+}
+
+explicit_choice choose_explicit_adapter(const selector_value &selector,
+                                         const choice_input *entries,
+                                         std::size_t count,
+                                         bool game_luid_known,
+                                         LUID game_luid) noexcept
+{
+    if (selector.kind != selector_kind::explicit_luid ||
+        (entries == nullptr && count != 0))
+        return {explicit_decision::invalid_selector,
+                static_cast<std::size_t>(-1), {}};
+    if (!game_luid_known)
+        return {explicit_decision::game_luid_unknown,
+                static_cast<std::size_t>(-1), {}};
+
+    std::size_t found = static_cast<std::size_t>(-1);
+    std::size_t matches = 0;
+    for (std::size_t i = 0; i < count; ++i)
+    {
+        if (!luid_eq(entries[i].luid, selector.luid))
+            continue;
+        found = i;
+        ++matches;
+    }
+    if (matches == 0)
+        return {explicit_decision::not_found, static_cast<std::size_t>(-1), {}};
+    if (matches != 1)
+        return {explicit_decision::ambiguous, static_cast<std::size_t>(-1), {}};
+    if (luid_eq(entries[found].luid, game_luid))
+        return {explicit_decision::target_is_game,
+                static_cast<std::size_t>(-1), {}};
+    if (entries[found].software)
+        return {explicit_decision::target_is_software,
+                static_cast<std::size_t>(-1), {}};
+    return {explicit_decision::selected, found, entries[found].luid};
+}
+}

--- a/src/adapter_selection.hpp
+++ b/src/adapter_selection.hpp
@@ -1,0 +1,80 @@
+// MGPU Bridge - pure adapter-choice policy (T2)
+#pragma once
+
+#include <windows.h>
+#include <cstddef>
+#include <string_view>
+
+namespace mgpu::adapter
+{
+    struct choice_input
+    {
+        LUID luid{};
+        bool software = false;
+        UINT outputs = 0;
+    };
+
+    struct choice_result
+    {
+        bool valid = false;
+        bool game_luid_found = false;
+        bool degenerate = false;
+        std::size_t selected_index = static_cast<std::size_t>(-1);
+    };
+
+    // Existing automatic policy. The caller owns the enumerated table and
+    // keeps the binding on the returned LUID; selected_index is only the
+    // current table lookup. A missing game LUID always refuses before the
+    // output-count tiebreak.
+    choice_result choose_adapter(const choice_input *entries, std::size_t count,
+                                 LUID game_luid);
+
+    enum class selector_kind
+    {
+        automatic,
+        explicit_luid,
+        invalid,
+    };
+
+    struct selector_value
+    {
+        selector_kind kind = selector_kind::automatic;
+        LUID luid{};
+    };
+
+    // Parse the value supplied by the config reader. Accepted values are
+    // exactly "auto" or the current-run adapter log form
+    // 0xHIGH-0xLOW. Enumeration indices, descriptions, partial IDs, and
+    // trailing comments are invalid rather than guessed.
+    selector_value parse_secondary_adapter(std::string_view value) noexcept;
+
+    enum class explicit_decision
+    {
+        selected,
+        invalid_selector,
+        game_luid_unknown,
+        not_found,
+        ambiguous,
+        target_is_game,
+        target_is_software,
+    };
+
+    struct explicit_choice
+    {
+        explicit_decision why = explicit_decision::invalid_selector;
+        std::size_t selected_index = static_cast<std::size_t>(-1);
+        LUID selected_luid{};
+    };
+
+    // Production explicit-selector policy. Automatic selection is deliberately
+    // not represented here: callers must continue through choose_adapter(),
+    // preserving the existing default and its separate missing-game fix.
+    // A known swapchain game LUID is mandatory, but the explicit target does
+    // not infer or require that the game LUID appear in this enumeration: that
+    // remains the auto-path source-review concern.
+    explicit_choice choose_explicit_adapter(const selector_value &selector,
+                                             const choice_input *entries,
+                                             std::size_t count,
+                                             bool game_luid_known,
+                                             LUID game_luid) noexcept;
+}

--- a/src/adapter_selection.hpp
+++ b/src/adapter_selection.hpp
@@ -3,7 +3,6 @@
 
 #include <windows.h>
 #include <cstddef>
-#include <string_view>
 
 namespace mgpu::adapter
 {
@@ -22,59 +21,10 @@ namespace mgpu::adapter
         std::size_t selected_index = static_cast<std::size_t>(-1);
     };
 
-    // Existing automatic policy. The caller owns the enumerated table and
-    // keeps the binding on the returned LUID; selected_index is only the
-    // current table lookup. A missing game LUID always refuses before the
-    // output-count tiebreak.
+    // Select only when the authoritative game LUID is present in the
+    // enumerated table. A missing game adapter is never evidence that every
+    // hardware adapter is a candidate: selecting one in that state can bind
+    // the bridge to the wrong GPU.
     choice_result choose_adapter(const choice_input *entries, std::size_t count,
                                  LUID game_luid);
-
-    enum class selector_kind
-    {
-        automatic,
-        explicit_luid,
-        invalid,
-    };
-
-    struct selector_value
-    {
-        selector_kind kind = selector_kind::automatic;
-        LUID luid{};
-    };
-
-    // Parse the value supplied by the config reader. Accepted values are
-    // exactly "auto" or the current-run adapter log form
-    // 0xHIGH-0xLOW. Enumeration indices, descriptions, partial IDs, and
-    // trailing comments are invalid rather than guessed.
-    selector_value parse_secondary_adapter(std::string_view value) noexcept;
-
-    enum class explicit_decision
-    {
-        selected,
-        invalid_selector,
-        game_luid_unknown,
-        not_found,
-        ambiguous,
-        target_is_game,
-        target_is_software,
-    };
-
-    struct explicit_choice
-    {
-        explicit_decision why = explicit_decision::invalid_selector;
-        std::size_t selected_index = static_cast<std::size_t>(-1);
-        LUID selected_luid{};
-    };
-
-    // Production explicit-selector policy. Automatic selection is deliberately
-    // not represented here: callers must continue through choose_adapter(),
-    // preserving the existing default and its separate missing-game fix.
-    // A known swapchain game LUID is mandatory, but the explicit target does
-    // not infer or require that the game LUID appear in this enumeration: that
-    // remains the auto-path source-review concern.
-    explicit_choice choose_explicit_adapter(const selector_value &selector,
-                                             const choice_input *entries,
-                                             std::size_t count,
-                                             bool game_luid_known,
-                                             LUID game_luid) noexcept;
 }

--- a/tests/adapter_selection_test.cpp
+++ b/tests/adapter_selection_test.cpp
@@ -1,0 +1,141 @@
+#include "adapter_selection.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace
+{
+    LUID luid(LONG high, DWORD low)
+    {
+        LUID out{};
+        out.HighPart = high;
+        out.LowPart = low;
+        return out;
+    }
+
+    void require(bool condition, const char *message)
+    {
+        if (!condition)
+        {
+            std::fprintf(stderr, "adapter selection regression: %s\n", message);
+            std::exit(1);
+        }
+    }
+
+    void check_case(const char *name, const mgpu::adapter::choice_input *entries,
+                    std::size_t count, LUID game_luid, bool expect_valid,
+                    std::size_t expect_index, bool expect_game_found,
+                    bool expect_degenerate)
+    {
+        const auto result = mgpu::adapter::choose_adapter(entries, count, game_luid);
+        char message[256];
+        std::snprintf(message, sizeof message, "%s: unexpected valid result", name);
+        require(result.valid == expect_valid, message);
+        std::snprintf(message, sizeof message, "%s: unexpected game-LUID presence", name);
+        require(result.game_luid_found == expect_game_found, message);
+        std::snprintf(message, sizeof message, "%s: unexpected selected index", name);
+        require(result.selected_index == expect_index, message);
+        std::snprintf(message, sizeof message, "%s: unexpected degenerate result", name);
+        require(result.degenerate == expect_degenerate, message);
+    }
+}
+
+int main()
+{
+    using mgpu::adapter::choice_input;
+
+    // Missing authoritative game identity must refuse for every hardware
+    // count, including the old >2-device output-count corner case.
+    const choice_input missing_one[] = {
+        {luid(0, 1), false, 1},
+    };
+    check_case("missing game with one hardware adapter", missing_one, 1,
+               luid(0, 99), false, static_cast<std::size_t>(-1), false, false);
+
+    const choice_input missing_two[] = {
+        {luid(0, 1), false, 0},
+        {luid(0, 2), false, 1},
+    };
+    check_case("missing game with two hardware adapters", missing_two, 2,
+               luid(0, 99), false, static_cast<std::size_t>(-1), false, false);
+
+    const choice_input missing_three[] = {
+        {luid(0, 1), false, 0},
+        {luid(0, 2), false, 1},
+        {luid(0, 3), false, 0},
+    };
+    check_case("missing game with three hardware adapters", missing_three, 3,
+               luid(0, 99), false, static_cast<std::size_t>(-1), false, false);
+
+    // Normal two-GPU exclusion remains selectable.
+    const choice_input two_gpu[] = {
+        {luid(0, 10), false, 1},
+        {luid(0, 11), false, 0},
+    };
+    check_case("two-GPU exclusion", two_gpu, 2, luid(0, 10), true, 1, true,
+               false);
+
+    // Software entries are excluded from candidates, but a software game
+    // adapter still proves that the authoritative game LUID was found.
+    const choice_input software_filter[] = {
+        {luid(0, 20), false, 1},
+        {luid(0, 21), true, 1},
+        {luid(0, 22), false, 0},
+    };
+    check_case("software filtering", software_filter, 3, luid(0, 20), true, 2,
+               true, false);
+
+    const choice_input software_game[] = {
+        {luid(0, 30), true, 0},
+        {luid(0, 31), false, 0},
+    };
+    check_case("software game adapter", software_game, 2, luid(0, 30), true, 1,
+               true, false);
+
+    const choice_input no_candidates[] = {
+        {luid(0, 40), false, 1},
+        {luid(0, 41), true, 0},
+    };
+    check_case("no hardware candidates", no_candidates, 2, luid(0, 40), false,
+               static_cast<std::size_t>(-1), true, false);
+
+    // The documented >2-hardware output tiebreak remains valid when the game
+    // LUID is present and exactly one non-game candidate has outputs.
+    const choice_input unique_output[] = {
+        {luid(0, 50), false, 1},
+        {luid(0, 51), false, 1},
+        {luid(0, 52), false, 0},
+    };
+    check_case("unique output tiebreak", unique_output, 3, luid(0, 50), true,
+               1, true, true);
+
+    const choice_input ambiguous_output[] = {
+        {luid(0, 60), false, 1},
+        {luid(0, 61), false, 1},
+        {luid(0, 62), false, 1},
+    };
+    check_case("ambiguous output tiebreak", ambiguous_output, 3, luid(0, 60),
+               false, static_cast<std::size_t>(-1), true, false);
+
+    // LUID comparison must include HighPart; matching only LowPart would
+    // incorrectly treat the second entry as the game adapter.
+    const choice_input high_luid_mismatch[] = {
+        {luid(1, 0x1234), false, 1},
+        {luid(2, 0x1234), false, 0},
+        {luid(9, 0x9999), true, 0},
+    };
+    check_case("high LUID half mismatch", high_luid_mismatch, 3,
+               luid(1, 0x1234), true, 1, true, false);
+
+    // Selection is based on identity, not enumeration position; reordering
+    // the same topology must select the entry that is now at index zero.
+    const choice_input reordered[] = {
+        {luid(0, 71), false, 0},
+        {luid(0, 70), false, 1},
+        {luid(0, 72), true, 0},
+    };
+    check_case("enumeration reorder", reordered, 3, luid(0, 70), true, 0,
+               true, false);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

When the swapchain-derived game adapter LUID is absent from the DXGI enumeration, the bridge must not infer the target from output counts. This change makes the game LUID a hard identity gate before candidate and tiebreak selection, while preserving the existing known-LUID rules.

The selection policy is factored into a small pure helper so the safety boundary is directly regression-tested. The adapter integration retains the existing software filtering, two-GPU exclusion, and explicitly unique >2-GPU output tiebreak only when the game LUID is present.

## Regression coverage

The table-driven CPU-only test covers:

- missing game LUID with one, two, and three hardware adapters;
- software filtering and a software game adapter;
- no hardware candidates;
- unique and ambiguous output tiebreaks;
- LUID high-half mismatch; and
- enumeration reorder.

## Validation

- MSVC Release CPU-only CTest: `mgpu_adapter_selection_test` passed.
- MSVC x64 Release add-on target built successfully as `mgpu_bridge.addon64` with the repository's pinned public headers.
- A follow-up scope correction removes unused selector-parser and explicit-selector API from the helper; the PR remains limited to automatic missing-game-LUID correctness.

This PR is a correctness fix only; it makes no performance, DLSS, or any-game support claim.