### PR TITLE
fix: reject partial and malformed mgpu.ini reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,18 @@ Two settings in `mgpu.ini` are worth knowing before the first launch:
 a hotkey first. Set it to `0` before measuring anything: every published figure
 was armed by hand, in gameplay, at a moment that was chosen.
 
+### Configuration file boundary
+
+The reader accepts the existing line-oriented `key=value` syntax, leading
+spaces/tabs, and whole-line `;` or `#` comments. It accepts UTF-8 files with an
+optional UTF-8 BOM; UTF-16, malformed UTF-8, embedded NULs, and unsupported
+control bytes are rejected. The complete file is bounded at 64 KiB (65535
+payload bytes, with one byte reserved for the terminator). This is intentionally
+large enough for the shipped comment-heavy `mgpu.ini`. A file beyond the bound
+is rejected as a whole rather than being clipped, so a setting after a long
+comment cannot silently fall back to a default. The diagnostic identifies the
+rejection and the documented built-in defaults remain in force.
+
 ---
 
 ## Limitations

--- a/src/gpu1_context.cpp
+++ b/src/gpu1_context.cpp
@@ -18,6 +18,7 @@
 #include "adapter.hpp"
 #include "diag.hpp"
 #include "gpu1_context.hpp"
+#include "mgpu_ini_parser.hpp"
 
 // P1.0: the NGX headers, fetched by CI into ext/ngx/ and never committed
 // (THIRD_PARTY.md, "NVIDIA NGX headers"). CMakeLists.txt is closed and
@@ -6834,31 +6835,20 @@ namespace
     // ini_find returns a pointer just past "<key>=" for the first occurrence
     // that starts a line (leading spaces and tabs allowed) and is not preceded
     // on that line by ';' or '#'. Returns nullptr when there is no such line.
+    // The bounded, BOM-aware implementation is shared with the portable
+    // regression test; this wrapper preserves the existing call sites.
     const char *ini_find(const char *buf, const char *key)
     {
-        const size_t klen = strlen(key);
-        const char *p = buf;
-        while (*p != '\0')
-        {
-            // p is at the start of a line. Skip leading blanks.
-            const char *q = p;
-            while (*q == ' ' || *q == '\t') ++q;
-            if (*q != ';' && *q != '#' &&
-                strncmp(q, key, klen) == 0 && q[klen] == '=')
-                return q + klen + 1;
-            // advance to the next line
-            while (*p != '\0' && *p != '\n') ++p;
-            if (*p == '\n') ++p;
-        }
-        return nullptr;
+        return mgpu::config::find(buf, strlen(buf), key);
     }
 
-    // Reads the file once into `buf`. False when there is nothing to read -
-    // callers then keep their default, because a missing or unreadable
-    // mgpu.ini must never be a reason a run does not happen.
-    // The ini is read whole into a stack buffer. 8 KB is far more than any
-    // sane config, and anything beyond it is now reported rather than dropped.
-    static const size_t INI_BYTES = 8192;
+    // Reads the file once into `buf`. False when there is nothing to read or
+    // the document is malformed. Callers then keep their documented defaults;
+    // a malformed document is rejected as a whole, never partially applied.
+    // The ini is read whole into a bounded stack buffer. 64 KiB accommodates
+    // the shipped comment-heavy config while keeping malformed/unbounded
+    // input from driving allocation or a partial parse.
+    static const size_t INI_BYTES = mgpu::config::MAX_BYTES + 1;
 
     // DEFECT D, found on the rig 2026-09-05 and fixed here. This read 1023
     // bytes into a 1024-byte buffer AND SAID NOTHING when the file was longer.
@@ -6874,8 +6864,8 @@ namespace
     // was perfectly well-formed. Section 00 again.
     //
     // Two changes, and the second one matters more than the first: the buffer
-    // is now 8 KB, and a file that does not fit is REPORTED BY NAME rather
-    // than quietly clipped.
+    // is now bounded at 64 KiB, and a file that does not fit is rejected
+    // rather than quietly clipped or partially applied.
     // P7.2. DEFECT G. mgpu.ini was opened as a BARE RELATIVE PATH, so it
     // resolved against the process's CURRENT WORKING DIRECTORY - which is not
     // the add-on's folder, is not something the add-on controls, and is not
@@ -6934,6 +6924,11 @@ namespace
 
     bool ini_slurp(char *buf, size_t n)
     {
+        if (buf == nullptr || n < 2)
+        {
+            mgpu::diag::error("[MGPU][P6.1] internal mgpu.ini buffer is too small; rejecting config");
+            return false;
+        }
         buf[0] = '\0';
         FILE *f = nullptr;
         bool beside = false;
@@ -6978,6 +6973,7 @@ namespace
         const size_t got = fread(buf, 1, n - 1, f);
         // Is there anything left? One byte past what we took is enough to know.
         const bool truncated = (fgetc(f) != EOF);
+        const bool read_error = ferror(f) != 0;
         fclose(f);
         buf[got] = '\0';
         if (truncated)
@@ -6988,15 +6984,46 @@ namespace
                 said = true;
                 char tl[400];
                 snprintf(tl, sizeof tl,
-                         "[MGPU][P6.1] mgpu.ini is LARGER than this build reads (%zu bytes taken, "
-                         "more follow). EVERY KEY PAST THAT POINT READS AS ABSENT AND ITS DEFAULT "
-                         "IS USED SILENTLY. Shorten the file or move the keys you care about to "
-                         "the top; the values reported on the arm line are what actually took "
-                         "effect.", got);
+                         "[MGPU][P6.1] mgpu.ini is larger than the %zu-byte limit (%zu bytes read, "
+                         "more follow). The complete config is REJECTED; no partial keys are applied "
+                         "and documented built-in defaults are used. Shorten comments or the file.",
+                         mgpu::config::MAX_BYTES, got);
                 mgpu::diag::error(tl);
             }
+            return false;
         }
-        return got != 0;
+        if (read_error)
+        {
+            mgpu::diag::error("[MGPU][P6.1] mgpu.ini read error; complete config rejected and built-in defaults used");
+            return false;
+        }
+        const mgpu::config::validation result = mgpu::config::validate(buf, got);
+        if (result != mgpu::config::validation::ok)
+        {
+            const char *reason = "invalid text";
+            switch (result)
+            {
+            case mgpu::config::validation::invalid_input: reason = "invalid input pointer"; break;
+            case mgpu::config::validation::empty: reason = "empty file"; break;
+            case mgpu::config::validation::utf16_bom: reason = "UTF-16 BOM (only UTF-8 is supported)"; break;
+            case mgpu::config::validation::embedded_nul: reason = "embedded NUL byte"; break;
+            case mgpu::config::validation::invalid_control: reason = "unsupported control byte"; break;
+            case mgpu::config::validation::invalid_utf8: reason = "malformed UTF-8"; break;
+            case mgpu::config::validation::too_large: reason = "size limit exceeded"; break;
+            case mgpu::config::validation::ok: break;
+            }
+            char ml[320];
+            snprintf(ml, sizeof ml,
+                     "[MGPU][P6.1] mgpu.ini rejected (%s); no partial keys are applied and documented "
+                     "built-in defaults are used.", reason);
+            mgpu::diag::error(ml);
+            return false;
+        }
+        // UTF-8 BOM is valid and common on Windows. Strip it before the
+        // existing line reader sees the first key; UTF-16 is rejected above.
+        size_t usable = got;
+        mgpu::config::strip_utf8_bom(buf, usable);
+        return usable != 0;
     }
 
     // P5.2. DEFECT C's second half. The one-shot probe chain (P1.3 transit,

--- a/src/mgpu_ini_parser.hpp
+++ b/src/mgpu_ini_parser.hpp
@@ -1,0 +1,124 @@
+// Portable, bounded parser primitives for the public mgpu.ini format.
+//
+// This header intentionally contains no Windows or ReShade dependency so the
+// reader's boundary behavior can be regression-tested without loading a DLL.
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+
+namespace mgpu::config
+{
+// The file buffer keeps one byte for a terminating NUL.  The limit is a
+// contract: a document at or below it is parsed in full; a larger document is
+// rejected before any setting is consumed.
+// 64 KiB is deliberately large enough for the shipped, comment-heavy
+// configuration while still making allocation and read behavior bounded.
+static constexpr std::size_t MAX_BYTES = 65535;
+
+enum class validation
+{
+    invalid_input,
+    ok,
+    empty,
+    too_large,
+    utf16_bom,
+    embedded_nul,
+    invalid_control,
+    invalid_utf8,
+};
+
+inline bool has_utf8_bom(const char *data, std::size_t size) noexcept
+{
+    return size >= 3 && static_cast<unsigned char>(data[0]) == 0xEFu &&
+           static_cast<unsigned char>(data[1]) == 0xBBu &&
+           static_cast<unsigned char>(data[2]) == 0xBFu;
+}
+
+inline validation validate(const char *data, std::size_t size) noexcept
+{
+    if (data == nullptr) return validation::invalid_input;
+    if (size == 0) return validation::empty;
+    if (size > MAX_BYTES) return validation::too_large;
+    if (size >= 2 && ((static_cast<unsigned char>(data[0]) == 0xFFu &&
+                       static_cast<unsigned char>(data[1]) == 0xFEu) ||
+                      (static_cast<unsigned char>(data[0]) == 0xFEu &&
+                       static_cast<unsigned char>(data[1]) == 0xFFu)))
+        return validation::utf16_bom;
+
+    std::size_t i = has_utf8_bom(data, size) ? 3u : 0u;
+    while (i < size)
+    {
+        const unsigned char c = static_cast<unsigned char>(data[i]);
+        // Config syntax is text.  NUL is never a valid byte in a file read
+        // from disk, and other C0 controls cannot be represented safely in
+        // line-oriented parsing.  Tabs and CR/LF remain valid for INI syntax.
+        if (c == 0u) return validation::embedded_nul;
+        if (c < 0x20u && c != '\t' && c != '\r' && c != '\n')
+            return validation::invalid_control;
+        if (c < 0x80u) { ++i; continue; }
+
+        // Validate UTF-8 so a truncated/malformed comment cannot make the
+        // reader walk a different byte sequence than the file contained.
+        std::size_t need = 0;
+        unsigned int codepoint = 0;
+        if (c >= 0xC2u && c <= 0xDFu) { need = 1; codepoint = c & 0x1Fu; }
+        else if (c >= 0xE0u && c <= 0xEFu) { need = 2; codepoint = c & 0x0Fu; }
+        else if (c >= 0xF0u && c <= 0xF4u) { need = 3; codepoint = c & 0x07u; }
+        else return validation::invalid_utf8;
+        if (i + need >= size) return validation::invalid_utf8;
+        for (std::size_t j = 1; j <= need; ++j)
+        {
+            const unsigned char t = static_cast<unsigned char>(data[i + j]);
+            if ((t & 0xC0u) != 0x80u) return validation::invalid_utf8;
+            codepoint = (codepoint << 6) | (t & 0x3Fu);
+        }
+        if ((need == 2 && codepoint < 0x800u) ||
+            (need == 3 && codepoint < 0x10000u) ||
+            codepoint > 0x10FFFFu ||
+            (codepoint >= 0xD800u && codepoint <= 0xDFFFu))
+            return validation::invalid_utf8;
+        i += need + 1;
+    }
+    return validation::ok;
+}
+
+// Remove a leading UTF-8 BOM in-place after validate() has accepted it.  A
+// UTF-16 BOM is intentionally not accepted: this public reader is byte-based,
+// and treating UTF-16 as if it were ASCII would silently ignore every key.
+inline bool strip_utf8_bom(char *data, std::size_t &size) noexcept
+{
+    if (data == nullptr) return false;
+    if (!has_utf8_bom(data, size)) return false;
+    std::memmove(data, data + 3, size - 3);
+    size -= 3;
+    data[size] = '\0';
+    return true;
+}
+
+// Find the first active, line-start key while preserving the existing syntax:
+// optional leading spaces/tabs, key=, and ';'/'#' whole-line comments.
+inline const char *find(const char *data, std::size_t size, const char *key) noexcept
+{
+    if (data == nullptr || key == nullptr) return nullptr;
+    const std::size_t key_size = std::strlen(key);
+    std::size_t p = has_utf8_bom(data, size) ? 3u : 0u;
+    while (p < size)
+    {
+        const std::size_t line_end = [&]() {
+            std::size_t e = p;
+            while (e < size && data[e] != '\n') ++e;
+            return e;
+        }();
+        std::size_t q = p;
+        while (q < line_end && (data[q] == ' ' || data[q] == '\t')) ++q;
+        if (q < line_end && data[q] != ';' && data[q] != '#' &&
+            key_size <= line_end - q &&
+            std::memcmp(data + q, key, key_size) == 0 &&
+            q + key_size < line_end && data[q + key_size] == '=')
+            return data + q + key_size + 1;
+        p = (line_end < size) ? line_end + 1 : size;
+    }
+    return nullptr;
+}
+} // namespace mgpu::config

--- a/tests/mgpu_ini_parser_test.cpp
+++ b/tests/mgpu_ini_parser_test.cpp
@@ -1,0 +1,133 @@
+#include "../src/mgpu_ini_parser.hpp"
+
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using mgpu::config::MAX_BYTES;
+using mgpu::config::validation;
+
+static void expect(validation got, validation want, const char *name)
+{
+    if (got != want)
+    {
+        std::cerr << "FAIL: " << name << "\n";
+        std::abort();
+    }
+}
+
+// This is the bounded-read behavior that existed before the candidate: take
+// the first 8191 bytes and let the ordinary line reader decide what is there.
+// Keeping it in the executable makes the regression an actual before/after
+// check rather than a source-text claim.
+static bool legacy_reader_finds_passes(const std::string &text)
+{
+    const std::size_t legacy_limit = 8191;
+    const std::size_t taken = (text.size() < legacy_limit) ? text.size() : legacy_limit;
+    std::string clipped(text.data(), taken);
+    clipped.push_back('\0');
+    const char *p = clipped.c_str();
+    const char *key = "Passes";
+    const std::size_t key_size = std::strlen(key);
+    while (*p != '\0')
+    {
+        const char *q = p;
+        while (*q == ' ' || *q == '\t') ++q;
+        if (*q != ';' && *q != '#' && std::strncmp(q, key, key_size) == 0 &&
+            q[key_size] == '=')
+            return true;
+        while (*p != '\0' && *p != '\n') ++p;
+        if (*p == '\n') ++p;
+    }
+    return false;
+}
+
+static void truncation_regression()
+{
+    std::string text(MAX_BYTES / 2, '#');
+    text += "\n";
+    text.append(MAX_BYTES / 2 - 20, '#');
+    text += "\nPasses=4\n";
+    assert(text.size() > 8191);
+
+    // The old bounded reader cannot see a setting beyond its 8191-byte read.
+    assert(!legacy_reader_finds_passes(text));
+    // The candidate parser validates and finds the same setting in full.
+    expect(mgpu::config::validate(text.data(), text.size()), validation::ok,
+           "overlong-comment candidate document");
+    const char *passes = mgpu::config::find(text.data(), text.size(), "Passes");
+    assert(passes != nullptr && std::strncmp(passes, "4", 1) == 0);
+    std::cout << "PASS: executable baseline reader fails and bounded candidate reader passes\n";
+}
+
+int main(int argc, char **argv)
+{
+    expect(mgpu::config::validate(nullptr, 1), validation::invalid_input, "null input");
+    truncation_regression();
+
+    if (argc > 1)
+    {
+        std::ifstream in(argv[1], std::ios::binary);
+        assert(in.good());
+        const std::string text((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        expect(mgpu::config::validate(text.data(), text.size()), validation::ok,
+               "shipped comment-heavy config");
+        const char *passes = mgpu::config::find(text.data(), text.size(), "Passes");
+        assert(passes != nullptr && std::strncmp(passes, "1", 1) == 0);
+        std::cout << "PASS: shipped comment-heavy mgpu.ini is read in full\n";
+        return 0;
+    }
+
+    {
+        const char text[] = "; Passes=99\r\n  Passes=4\r\n# Frames=3\r\nFrames=120\r\n";
+        expect(mgpu::config::validate(text, sizeof(text) - 1), validation::ok, "ordinary config");
+        const char *passes = mgpu::config::find(text, sizeof(text) - 1, "Passes");
+        const char *frames = mgpu::config::find(text, sizeof(text) - 1, "Frames");
+        assert(passes != nullptr && std::strncmp(passes, "4", 1) == 0);
+        assert(frames != nullptr && std::strncmp(frames, "120", 3) == 0);
+    }
+
+    {
+        const char text[] = "\xEF\xBB\xBFPasses=4\n";
+        expect(mgpu::config::validate(text, sizeof(text) - 1), validation::ok, "UTF-8 BOM");
+        const char *passes = mgpu::config::find(text, sizeof(text) - 1, "Passes");
+        assert(passes != nullptr && std::strncmp(passes, "4", 1) == 0);
+    }
+
+    {
+        const char text[] = "\xFF\xFEP\0a\0s\0s\0e\0s\0=\0";
+        expect(mgpu::config::validate(text, sizeof(text) - 1), validation::utf16_bom, "UTF-16 BOM");
+    }
+    {
+        const char text[] = "Passes=4\0Frames=120";
+        expect(mgpu::config::validate(text, sizeof(text) - 1), validation::embedded_nul, "embedded NUL");
+    }
+    {
+        const char text[] = "# bad UTF-8: \xC3\x28\nPasses=4\n";
+        expect(mgpu::config::validate(text, sizeof(text) - 1), validation::invalid_utf8, "malformed UTF-8");
+    }
+    {
+        const char text[] = "Passes=4\x01\n";
+        expect(mgpu::config::validate(text, sizeof(text) - 1), validation::invalid_control, "control byte");
+    }
+
+    // A key at the final byte of the bounded document must still be visible.
+    {
+        std::string text(MAX_BYTES - 9, '#');
+        text += "\nPasses=4";
+        assert(text.size() == MAX_BYTES);
+        expect(mgpu::config::validate(text.data(), text.size()), validation::ok, "exact boundary");
+        const char *passes = mgpu::config::find(text.data(), text.size(), "Passes");
+        assert(passes != nullptr && std::strncmp(passes, "4", 1) == 0);
+    }
+    {
+        std::string text(MAX_BYTES + 1, '#');
+        expect(mgpu::config::validate(text.data(), text.size()), validation::too_large,
+               "overlong comment rejected");
+    }
+
+    std::cout << "PASS: mgpu.ini parser boundary, BOM, malformed-input, and comment tests\n";
+    return 0;
+}

--- a/tests/run_mgpu_ini_parser_test.ps1
+++ b/tests/run_mgpu_ini_parser_test.ps1
@@ -1,0 +1,76 @@
+$ErrorActionPreference = 'Stop'
+
+# Standalone runner: it uses only this candidate's source/tests/assets, always
+# creates a fresh output directory, always compiles, and never accepts a stale
+# executable as a green result.
+$testRoot = $PSScriptRoot
+$root = Split-Path -Parent $testRoot
+$asset = Join-Path $root 'assets\mgpu.ini'
+$cpp = Join-Path $testRoot 'mgpu_ini_parser_test.cpp'
+$testScratch = Join-Path $testRoot ('.test-tmp-' + [guid]::NewGuid().ToString('N'))
+$buildDir = $testScratch
+$out = Join-Path $buildDir 'mgpu_ini_parser_test.exe'
+$obj = Join-Path $buildDir 'mgpu_ini_parser_test.obj'
+
+try {
+    if (-not (Test-Path -LiteralPath $asset -PathType Leaf)) {
+        throw "public shipped config is missing: $asset"
+    }
+    New-Item -ItemType Directory -Path $buildDir -Force | Out-Null
+
+    $clCommand = Get-Command cl.exe -ErrorAction SilentlyContinue
+    $compileExit = $null
+    if ($null -ne $clCommand) {
+        Push-Location $buildDir
+        try {
+            & $clCommand.Source /nologo /std:c++17 /EHsc /W4 `
+                "/I$root\src" "/Fo$obj" "/Fe$out" $cpp
+            $compileExit = $LASTEXITCODE
+        }
+        finally { Pop-Location }
+    }
+    else {
+        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+        if (-not (Test-Path -LiteralPath $vswhere -PathType Leaf)) {
+            throw 'MSVC cl.exe was not available and vswhere.exe was not found.'
+        }
+        $install = (& $vswhere -latest -products '*' -property installationPath | Select-Object -First 1).Trim()
+        $vcvars = Join-Path $install 'VC\Auxiliary\Build\vcvars64.bat'
+        if (-not (Test-Path -LiteralPath $vcvars -PathType Leaf)) {
+            throw "MSVC vcvars64.bat was not found: $vcvars"
+        }
+        $compileLine = 'call "' + $vcvars + '" && cl.exe /nologo /std:c++17 /EHsc /W4 ' +
+            '/I"' + (Join-Path $root 'src') + '" /Fo"' + $obj + '" /Fe"' + $out + '" "' + $cpp + '"'
+        Push-Location $buildDir
+        try {
+            cmd.exe /d /s /c $compileLine
+            $compileExit = $LASTEXITCODE
+        }
+        finally { Pop-Location }
+    }
+    if ($compileExit -ne 0) {
+        throw "focused parser compile failed with exit code $compileExit"
+    }
+    if (-not (Test-Path -LiteralPath $out -PathType Leaf)) {
+        throw 'focused parser compile reported success but produced no executable'
+    }
+
+    & $out
+    if ($LASTEXITCODE -ne 0) { throw "parser integration test exited with $LASTEXITCODE" }
+    & $out $asset
+    if ($LASTEXITCODE -ne 0) { throw "shipped-config parser test exited with $LASTEXITCODE" }
+}
+finally {
+    if (Test-Path -LiteralPath $buildDir) {
+        $resolvedTests = [IO.Path]::GetFullPath($testRoot)
+        $resolvedBuild = [IO.Path]::GetFullPath($buildDir)
+        $buildLeaf = [IO.Path]::GetFileName($resolvedBuild)
+        $buildParent = [IO.Path]::GetDirectoryName($resolvedBuild)
+        $safeLeaf = $buildLeaf -match '^\.test-tmp-[0-9a-f]{32}$'
+        $safeParent = $buildParent.Equals($resolvedTests, [StringComparison]::OrdinalIgnoreCase)
+        if (-not ($safeLeaf -and $safeParent)) {
+            throw "refusing to remove unexpected temporary path: $resolvedBuild"
+        }
+        Remove-Item -LiteralPath $buildDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary

Fixes partial `mgpu.ini` reads. The current 8192-byte buffer accepts a clipped document after warning; the shipped configuration is already 8949 bytes. Settings after the cutoff are consequently indistinguishable from missing settings.

- Increase the bounded payload to 65535 bytes and reject the complete document on overflow/read failure rather than applying a prefix.
- Share the bounded line-key parser with a portable regression executable.
- Support an optional UTF-8 BOM and explicitly reject UTF-16, malformed UTF-8, embedded NULs and unsupported control bytes.
- Preserve existing key syntax, first-active-key behavior and documented default values on rejection.
- Document the size/encoding contract and add a standalone Windows test runner that always builds fresh output.

## Validation

- Windows MSVC 19.44 / SDK 10.0.26100 Release add-on build: **passed** (`cmake --build build --config Release --parallel 1`).
- Standalone portable test: **passed** (`powershell -NoProfile -File tests/run_mgpu_ini_parser_test.ps1`).
- Executable before/after fixture reproduces the legacy clipped-reader behavior: trailing `Passes=4` is missed by the 8191-byte read and found by the new shared parser.
- Parser tests cover comments, CRLF, UTF-8 BOM, malformed encodings, NUL/control bytes, null input, the exact size limit and overflow.
- The repository's own `assets/mgpu.ini` is validated and read in full.
- `git diff --check`: **passed**.

No game, GPU workload, NGX runtime or live add-on execution was performed for this patch. The native build and CPU regressions do not claim rendering/performance acceptance. No binaries or external runtime payloads are included.

The change is independent of the adapter-selection correction in #5 and is based only on this repository's public source.
